### PR TITLE
Deathwebo master

### DIFF
--- a/inc/bs_collapse.php
+++ b/inc/bs_collapse.php
@@ -18,7 +18,7 @@ function bs_citem( $params, $content=null ){
         'id'=> '',
         'title'=> 'Collapse title',
         'parent' => '',
-        'collapsed' => false,
+        'open' => 'false',
          ), $params ) );
     $content = preg_replace( '/<br class="nc".\/>/', '', $content );
     $result =  '<div class="panel panel-default">';
@@ -29,7 +29,7 @@ function bs_citem( $params, $content=null ){
     $result .= '</a>';
     $result .= '        </h4>';
     $result .= '    </div>';
-    $result .= '    <div id="' . $id . '" class="panel-collapse collapse '.($collapsed ? 'in' : '').'" role="tabpanel" aria-labelledby="heading_' . $id . '">';
+    $result .= '    <div id="' . $id . '" class="panel-collapse collapse '.($open=='true'? 'in' : '').'" role="tabpanel" aria-labelledby="heading_' . $id . '">';
     $result .= '        <div class="panel-body">';
     $result .= do_shortcode( $content );
     $result .= '        </div>';

--- a/js/plugins/collapse.js
+++ b/js/plugins/collapse.js
@@ -12,6 +12,11 @@
                         name: 'itemnum',
                         value: '3',
                         label: 'Number of items'
+                    },{
+                        type: 'checkbox',
+                        name: 'isopen',
+                        checked: false,
+                        label: 'Start open?'
                     }],
                     onsubmit: function(e) {
                         // Insert content when the window form is submitted
@@ -21,7 +26,12 @@
                         for (i = 0; i < num; i++) {
                             var id = guid();
                             var title = 'Collapsible Group Item ' + (i + 1);
-                            shortcode += '[bs_citem title="' + title + '" id="citem_' + id + '" parent="collapse_' + uID + '"]<br class="nc"/>';
+                            shortcode += '[bs_citem';
+                            shortcode += ' title="' + title + '"';
+                            shortcode += ' id="citem_' + id + '"';
+                            shortcode += ' parent="collapse_' + uID + '"';
+                            shortcode += (e.data.isopen? ' open="true"': '');
+                            shortcode += ']<br class="nc"/>';
                             shortcode += 'Collapse content goes here....<br class="nc"/>';
                             shortcode += '[/bs_citem]<br class="nc"/>';
                         }


### PR DESCRIPTION
Hey @deathwebo thanks for the pull request, I think that it's a great idea to allow users to control whether or not collapsible panels start open.

However, in order to maintain backwards compatibility we'll need them to start closed by default.

Also, I've added a checkbox to the user interface for controlling this new option.

<img width="477" alt="screen shot 2015-08-22 at 11 07 09 pm" src="https://cloud.githubusercontent.com/assets/1529452/9427173/89dca7b8-4922-11e5-86a4-4443c62e60c0.png">
